### PR TITLE
Ensure response body is not loaded in memory

### DIFF
--- a/src/DDown/Downloader.cs
+++ b/src/DDown/Downloader.cs
@@ -153,29 +153,21 @@ namespace DDown
 
         private async Task<Stream> GetBody(Partition partition)
         {
-            if (_status.IsRangeSupported)
+            var message = new HttpRequestMessage(HttpMethod.Get, _uri)
             {
-                var message = new HttpRequestMessage(HttpMethod.Get, _uri)
+                Headers =
                 {
-                    Headers =
+                    Range = new RangeHeaderValue
                     {
-                        Range = new RangeHeaderValue
-                        {
-                            Unit = "bytes",
-                            Ranges = {partition.GetHeader()}
-                        }
+                        Unit = "bytes",
+                        Ranges = {partition.GetHeader()}
                     }
-                };
+                }
+            };
 
-                var response = await _client.SendAsync(message);
-                var body = await response.Content.ReadAsStreamAsync();
-                return body;
-            }
-            else
-            {
-                var body = await _client.GetStreamAsync(_uri);
-                return body;
-            }
+            var response = await _client.SendAsync(message, HttpCompletionOption.ResponseHeadersRead);
+            var body = await response.Content.ReadAsStreamAsync();
+            return body;
         }
 
         private async Task DownloadPartitionAsync(Partition partition)


### PR DESCRIPTION
Hi! I've came across your issue dotnet/corefx#34223. 
We had a similar issue in our setup: we restream large zip archives from one microservice to another. For some reason SendAsync seems to load full response into memory, while GetStreamAsync is lazy. 
I've tried to use same approach in your case and it worked for me: memory reduced from 500mb to 15mb for downloading 0.5gb file and there was no delay in reporting progress. Hope I've done everything right and it will help you. 